### PR TITLE
input data error handling dla endpointu api_cv_post - do review

### DIFF
--- a/app/functions.py
+++ b/app/functions.py
@@ -1,6 +1,7 @@
 from app.models import SkillUser, SkillName, Experience, User
 from sqlalchemy.orm import Session
-from typing import List
+from typing import List, Tuple
+import logging
 
 
 def replace_skills_with_json(session: Session, cv: User, json_data: dict) -> None:
@@ -45,3 +46,8 @@ def parse_params(json: List[dict]) -> dict:
 
 def create_param_subs(json: List[dict]) -> str:
     return ', '.join(f':param{n}' for n in range(len(json)))
+
+
+def error_response(msg: str, status: int, ex: Exception) -> Tuple[dict, int]:
+    logging.exception(ex)
+    return {'error': msg}, status

--- a/app/main.py
+++ b/app/main.py
@@ -51,11 +51,6 @@ def api_cv_post() -> Tuple[dict, int]:
 
     session = get_session()
 
-    # if session.connection():
-    #     return "session"
-    # else:
-    #     return "no session"
-
     # create new_cv object and map basic user data from json:
     new_cv = User()
 

--- a/app/main.py
+++ b/app/main.py
@@ -1,4 +1,5 @@
 from flask import Flask, request, jsonify, Response, make_response
+from sqlalchemy.exc import OperationalError
 from typing import Tuple
 from app.models import User
 from app.session import get_session
@@ -36,6 +37,7 @@ def api_cv_post() -> Tuple[dict, int]:
     # ADD NEW CV BASED ON JSON DATA
 
     error_response = {'error': 'bad input data'}, 400
+    db_error_response = {'error': 'database error'}, 503
     success_response = {'success': 'item added'}, 201
 
     json_data = request.get_json()
@@ -48,6 +50,11 @@ def api_cv_post() -> Tuple[dict, int]:
             return error_response
 
     session = get_session()
+
+    # if session.connection():
+    #     return "session"
+    # else:
+    #     return "no session"
 
     # create new_cv object and map basic user data from json:
     new_cv = User()
@@ -63,6 +70,9 @@ def api_cv_post() -> Tuple[dict, int]:
 
     except KeyError:
         return error_response
+
+    except OperationalError:
+        return db_error_response
 
     session.add(new_cv)
     session.commit()


### PR DESCRIPTION
Założenia zgodnie z ostatnią rozmową:

Input data error handling 
    - zaimplementowac tylko dla post user
    - walidowac dane wejsciowe pod katem poprawnosci - czy sa poprawne klucze
    - nie moze byc 500 w zadnym wypadku
    - w przypadku bledu zwracac 400 + json o wartosci {"error": "bad input data"}
    - bledy nie moga byc luka bezpieczenstwa